### PR TITLE
Speed-up hashing and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --release --all
+          args: --verbose --release --all --all-features
 
   build:
     name: Build target ${{ matrix.target }}
@@ -73,7 +73,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all --benches
+          args: --all --benches --all-features
 
   clippy:
     name: Clippy
@@ -96,7 +96,7 @@ jobs:
         with:
           name: Clippy
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings
+          args: --all-targets --all-features -- -D warnings
 
   fmt:
     name: Rustfmt

--- a/src/rescue_63_14_7/mod.rs
+++ b/src/rescue_63_14_7/mod.rs
@@ -53,7 +53,7 @@ fn square_assign_multi_and_multiply<const N: usize, const M: usize>(
         result.iter_mut().for_each(|r| *r = r.square());
     }
 
-    result.iter_mut().zip(tail).for_each(|(r, t)| *r *= t);
+    result.iter_mut().zip(&tail).for_each(|(r, t)| *r *= t);
     result
 }
 
@@ -85,10 +85,10 @@ pub fn apply_inv_sbox(state: &mut [Fp; STATE_WIDTH]) {
     t1 = square_assign_multi_and_multiply::<STATE_WIDTH, 2>(t2, t1);
 
     let mut t5 = t0;
-    t5.iter_mut().zip(t1).for_each(|(r, t)| *r *= t);
+    t5.iter_mut().zip(&t1).for_each(|(r, t)| *r *= t);
 
     t2 = square_assign_multi_and_multiply::<STATE_WIDTH, 1>(t1, t4);
-    t0.iter_mut().zip(t2).for_each(|(r, t)| *r *= t);
+    t0.iter_mut().zip(&t2).for_each(|(r, t)| *r *= t);
 
     t0 = square_assign_multi_and_multiply::<STATE_WIDTH, 8>(t0, t2);
     t0 = square_assign_multi_and_multiply::<STATE_WIDTH, 8>(t0, t2);

--- a/src/rescue_63_14_7/mod.rs
+++ b/src/rescue_63_14_7/mod.rs
@@ -105,11 +105,12 @@ pub fn apply_inv_sbox(state: &mut [Fp; STATE_WIDTH]) {
 /// hash state with the Rescue MDS matrix.
 pub fn apply_mds(state: &mut [Fp; STATE_WIDTH]) {
     let mut result = [Fp::zero(); STATE_WIDTH];
-    for i in 0..STATE_WIDTH {
-        for j in 0..STATE_WIDTH {
-            result[i] += mds::MDS[i * STATE_WIDTH + j] * state[j];
+    for (i, r) in result.iter_mut().enumerate() {
+        for (j, s) in state.iter().enumerate() {
+            *r += mds::MDS[i * STATE_WIDTH + j] * s;
         }
     }
+
     state.copy_from_slice(&result);
 }
 

--- a/src/rescue_63_8_4/mod.rs
+++ b/src/rescue_63_8_4/mod.rs
@@ -53,7 +53,7 @@ fn square_assign_multi_and_multiply<const N: usize, const M: usize>(
         result.iter_mut().for_each(|r| *r = r.square());
     }
 
-    result.iter_mut().zip(tail).for_each(|(r, t)| *r *= t);
+    result.iter_mut().zip(&tail).for_each(|(r, t)| *r *= t);
     result
 }
 
@@ -85,10 +85,10 @@ pub fn apply_inv_sbox(state: &mut [Fp; STATE_WIDTH]) {
     t1 = square_assign_multi_and_multiply::<STATE_WIDTH, 2>(t2, t1);
 
     let mut t5 = t0;
-    t5.iter_mut().zip(t1).for_each(|(r, t)| *r *= t);
+    t5.iter_mut().zip(&t1).for_each(|(r, t)| *r *= t);
 
     t2 = square_assign_multi_and_multiply::<STATE_WIDTH, 1>(t1, t4);
-    t0.iter_mut().zip(t2).for_each(|(r, t)| *r *= t);
+    t0.iter_mut().zip(&t2).for_each(|(r, t)| *r *= t);
 
     t0 = square_assign_multi_and_multiply::<STATE_WIDTH, 8>(t0, t2);
     t0 = square_assign_multi_and_multiply::<STATE_WIDTH, 8>(t0, t2);

--- a/src/rescue_63_8_4/mod.rs
+++ b/src/rescue_63_8_4/mod.rs
@@ -105,11 +105,12 @@ pub fn apply_inv_sbox(state: &mut [Fp; STATE_WIDTH]) {
 /// hash state with the Rescue MDS matrix.
 pub fn apply_mds(state: &mut [Fp; STATE_WIDTH]) {
     let mut result = [Fp::zero(); STATE_WIDTH];
-    for i in 0..STATE_WIDTH {
-        for j in 0..STATE_WIDTH {
-            result[i] += mds::MDS[i * STATE_WIDTH + j] * state[j];
+    for (i, r) in result.iter_mut().enumerate() {
+        for (j, s) in state.iter().enumerate() {
+            *r += mds::MDS[i * STATE_WIDTH + j] * s;
         }
     }
+
     state.copy_from_slice(&result);
 }
 


### PR DESCRIPTION
This PR adds an additional 10% speedup on top of the previous PR #17.
Also compiles CI with all features enabled (and pacifies clippy for lints in Rescue-Prime modules)