### PR TITLE
Fix wrong compression of two Rescue-Prime instances

### DIFF
--- a/src/rescue_prime/rescue_64_14_7/hasher.rs
+++ b/src/rescue_prime/rescue_64_14_7/hasher.rs
@@ -164,7 +164,10 @@ impl Hasher<Fp> for RescueHash {
     fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
         let mut state = [Fp::zero(); STATE_WIDTH];
         state[..RATE_WIDTH].copy_from_slice(values[0].as_elements());
-        state[RATE_WIDTH..STATE_WIDTH].copy_from_slice(values[1].as_elements());
+        apply_permutation(&mut state);
+        for (index, value) in values[1].as_elements().iter().enumerate() {
+            state[index] += value;
+        }
         apply_permutation(&mut state);
 
         RescueDigest::new(state[..DIGEST_SIZE].try_into().unwrap())

--- a/src/rescue_prime/rescue_64_8_4/hasher.rs
+++ b/src/rescue_prime/rescue_64_8_4/hasher.rs
@@ -164,7 +164,10 @@ impl Hasher<Fp> for RescueHash {
     fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
         let mut state = [Fp::zero(); STATE_WIDTH];
         state[..RATE_WIDTH].copy_from_slice(values[0].as_elements());
-        state[RATE_WIDTH..STATE_WIDTH].copy_from_slice(values[1].as_elements());
+        apply_permutation(&mut state);
+        for (index, value) in values[1].as_elements().iter().enumerate() {
+            state[index] += value;
+        }
         apply_permutation(&mut state);
 
         RescueDigest::new(state[..DIGEST_SIZE].try_into().unwrap())


### PR DESCRIPTION
This PR fixes an implementation issue in two instantiations of Rescue-Prime with `RATE_WIDTH = DIGEST_SIZE`. The issue is that the current `merge()` compression function puts the second digest in the capacity registers, which should be left untouched.
Instead, merging requires here two calls to the underlying permutation function, to sequentially append the second digest.

The other instantiation that we use is unaffected, as the rate portion is large enough to contain the two provided digests.